### PR TITLE
Implement best_fit method and standardize parameter order

### DIFF
--- a/src/gwrefpy/methods/linregressfit.py
+++ b/src/gwrefpy/methods/linregressfit.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 def linregressfit(
-    ref_well: Well,
     obs_well: Well,
+    ref_well: Well,
     offset: pd.DateOffset | pd.Timedelta | str,
     tmin: pd.Timestamp | str | None = None,
     tmax: pd.Timestamp | str | None = None,
@@ -24,10 +24,10 @@ def linregressfit(
 
     Parameters
     ----------
-    ref_well : Well
-        The reference well object containing the time series data.
     obs_well : Well
         The observation well object containing the time series data.
+    ref_well : Well
+        The reference well object containing the time series data.
     offset: pd.DateOffset | pd.Timedelta | str
         The offset to apply when grouping the time series into time equivalents.
     tmin: pd.Timestamp | str | None = None
@@ -103,7 +103,7 @@ def linregressfit(
         return None
 
     ref_timeseries, obs_timeseries, n = groupby_time_equivalents(
-        ref_well.timeseries.loc[tmin:tmax], obs_well.timeseries.loc[tmin:tmax], offset
+        obs_well.timeseries.loc[tmin:tmax], ref_well.timeseries.loc[tmin:tmax], offset
     )
 
     res = sp.stats.linregress(ref_timeseries, obs_timeseries)

--- a/src/gwrefpy/methods/timeseries.py
+++ b/src/gwrefpy/methods/timeseries.py
@@ -7,8 +7,8 @@ from ..well import Well
 
 
 def groupby_time_equivalents(
-    ref_timeseries: pd.Series,
     obs_timeseries: pd.Series,
+    ref_timeseries: pd.Series,
     offset: pd.DateOffset | pd.Timedelta | str,
 ) -> tuple[pd.Series, pd.Series, int]:
     """
@@ -17,10 +17,10 @@ def groupby_time_equivalents(
 
     Parameters
     ----------
-    ref_timeseries : pd.Series
-        The reference timeseries data.
     obs_timeseries: pd.Series
         The observed timeseries data.
+    ref_timeseries : pd.Series
+        The reference timeseries data.
     offset: pd.DateOffset | pd.Timedelta | str
         Maximum date offset to allow to group pairs of data points.
 
@@ -33,16 +33,16 @@ def groupby_time_equivalents(
     int
         Number of grouped pairs of data points.
     """
-    if not ref_timeseries.name:
-        ref_timeseries.name = "ref"
     if not obs_timeseries.name:
         obs_timeseries.name = "obs"
+    if not ref_timeseries.name:
+        ref_timeseries.name = "ref"
 
     time_equivalents = _create_time_equivalents(
-        ref_timeseries.index, obs_timeseries.index, offset
+        obs_timeseries.index, ref_timeseries.index, offset
     )
 
-    combined = pd.concat([ref_timeseries, obs_timeseries], axis="columns")
+    combined = pd.concat([obs_timeseries, ref_timeseries], axis="columns")
     combined_time_eqs = combined.set_index(time_equivalents, drop=True)
     time_eq_means = combined_time_eqs.groupby(combined_time_eqs.index).mean()
 

--- a/src/gwrefpy/model.py
+++ b/src/gwrefpy/model.py
@@ -292,13 +292,16 @@ class Model(Plotter):
         if isinstance(obs_well, str):
             target_obs_well = self.get_wells(obs_well)
             if isinstance(target_obs_well, list):
+                logger.error(
+                    "obs_well parameter must resolve to a single well, not a list."
+                )
                 raise ValueError(
                     "obs_well parameter must resolve to a single well, not a list."
                 )
         elif isinstance(obs_well, Well):
             target_obs_well = obs_well
         if ref_wells is None:
-            target_ref_wells = [well for well in self.wells if well.is_reference]
+            target_ref_wells = self.ref_wells
             if len(target_ref_wells) < 1:
                 logger.error("No reference wells available in the model.")
                 raise ValueError("No reference wells available in the model.")
@@ -309,6 +312,14 @@ class Model(Plotter):
                     target_ref_wells.append(self.get_wells(rw))  # type: ignore
                 elif isinstance(rw, Well):
                     target_ref_wells.append(rw)
+                else:
+                    logger.error(
+                        f"Unsupported type for {rw}. Supported types are Well or str"
+                    )
+                    raise TypeError(
+                        f"Unsupported type for {rw}. Supported types are Well or str"
+                    )
+
         local_fits: list[FitResultData] = []
         for ref_well in target_ref_wells:
             logger.debug(

--- a/src/gwrefpy/plotter.py
+++ b/src/gwrefpy/plotter.py
@@ -66,8 +66,9 @@ class Plotter:
         num : int
             Number of ticks on the x-axis (default is 6).
         **kwargs : dict
-            Additional keyword arguments for customization. See the documentation of Matplotlib's
-            `plt.subplots` and `plt.savefig` for more details. Common kwargs include:
+            Additional keyword arguments for customization. See the documentation of
+            Matplotlib's `plt.subplots` and `plt.savefig` for more details.
+            Common kwargs include:
 
             - figsize (tuple): Size of the figure (width, height) in inches.
             - dpi (int): Dots per inch for the saved figure.

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -1,0 +1,46 @@
+from gwrefpy import Well
+from gwrefpy.fitresults import FitResultData
+
+
+def test_strandangers_model_basic_fit(strandangers_model) -> None:
+    assert strandangers_model.name == "Strandangers"
+    assert len(strandangers_model.wells) == 2
+    assert strandangers_model.wells[0].name == "obs"
+    assert strandangers_model.wells[1].name == "ref"
+
+    [obs, ref] = strandangers_model.wells
+
+    strandangers_model.fit(obs, ref, "3.5D")
+    [fit] = strandangers_model.fits
+    assert fit.n == 3
+    assert fit.offset == "3.5D"
+
+
+def test_strandangers_model_best_fit_by_names(strandangers_model) -> None:
+    # introduce a second reference well
+    ref = strandangers_model.get_wells("ref")  # type: Well
+    ts2 = ref.timeseries + 0.5
+    ref2 = Well("ref2", is_reference=True, timeseries=ts2)
+    strandangers_model.add_well(ref2)
+
+    best_fit = strandangers_model.best_fit("obs", ["ref", "ref2"], offset="3.5D")
+    assert isinstance(best_fit, FitResultData)
+
+    model_fits = strandangers_model.get_fits("obs")
+    assert len(model_fits) == 2
+
+    assert best_fit == min(model_fits, key=lambda x: x.rmse)
+
+
+def test_strandangers_model_best_fit_by_objects(strandangers_model) -> None:
+    # introduce a second reference well
+    [obs, ref] = strandangers_model.get_wells(["obs", "ref"])
+    ts2 = ref.timeseries + 0.5
+    ref2 = Well("ref2", is_reference=True, timeseries=ts2)
+    strandangers_model.add_well(ref2)
+
+    best_fit = strandangers_model.best_fit(obs, [ref, ref2], offset="3.5D")
+    assert isinstance(best_fit, FitResultData)
+
+    model_fits = strandangers_model.get_fits(obs)
+    assert len(model_fits) == 2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,4 @@
-from src.gwrefpy.model import Model
-from src.gwrefpy.well import Well
+from gwrefpy import Model, Well
 
 
 def test_add_well_to_model() -> None:
@@ -26,12 +25,10 @@ def test_add_well_to_model() -> None:
 def test_strandangers_model(strandangers_model) -> None:
     assert strandangers_model.name == "Strandangers"
     assert len(strandangers_model.wells) == 2
-    assert strandangers_model.wells[0].name == "obs"
-    assert strandangers_model.wells[1].name == "ref"
+    obs = strandangers_model.get_wells("obs")
+    ref = strandangers_model.get_wells("ref")
 
-    [obs, ref] = strandangers_model.wells
-
-    strandangers_model.fit(ref, obs, "3.5D")
-    [fit] = strandangers_model.fits
-    assert fit.n == 3
-    assert fit.offset == "3.5D"
+    assert isinstance(obs, Well)
+    assert isinstance(ref, Well)
+    assert obs.name == "obs"
+    assert ref.name == "ref"

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -7,7 +7,7 @@ from gwrefpy.methods.timeseries import groupby_time_equivalents
 def test_strandangers_example(strandangers_example) -> None:
     obs, ref = strandangers_example
 
-    ref_te, obs_te, n = groupby_time_equivalents(ref, obs, "3.5D")
+    ref_te, obs_te, n = groupby_time_equivalents(obs, ref, "3.5D")
     assert n == 3
     assert ref_te.tolist() == [8.9, 9.2, 9.4]
     assert obs_te.tolist() == [11.4, 11.7, 11.8]
@@ -34,7 +34,7 @@ def test_groupby_time_equivalents_no_pairs() -> None:
         data=[8.9, 9.2, 9.3, 9.3, 9.5],
         name="ref",
     )
-    ref_te, obs_te, n = groupby_time_equivalents(ref, obs, "7D")
+    ref_te, obs_te, n = groupby_time_equivalents(obs, ref, "7D")
     assert n == 0
     assert ref_te.tolist() == []
     assert obs_te.tolist() == []


### PR DESCRIPTION
- Add best_fit method to Model class that finds optimal reference well for given observation well
- Standardize parameter order across codebase: obs_well comes before ref_well
- Update function signatures in linregressfit and groupby_time_equivalents
- Improve type annotations and return types for better clarity
- Add comprehensive tests for new best_fit functionality
- Update existing tests to match new parameter order

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>