### PR TITLE
Specify line length for formatter check

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -30,7 +30,7 @@ jobs:
         run: uv run ruff check --fix
 
       - name: Run formatter check
-        run: uv run ruff format --check
+        run: uv run ruff format --check  --line-length 88
 
       - name: Run tests
         run: uv run python -m pytest tests/


### PR DESCRIPTION
Updated formatter check to specify line length.

We have 88 in the toml, so one has to change